### PR TITLE
updated understudy info with up to date information as of 3/3

### DIFF
--- a/src/data/understudy.yml
+++ b/src/data/understudy.yml
@@ -7,9 +7,8 @@ body: |
     This year, the Sysadmin Understudy program is composed of four stages.
 
     ### Interest Sessions
-    
-    There are no more interest sessions scheduled for this year (2021). If you still are interested, please join [this Slack channel](https://tjcsl.slack.com) using your TJHSST student email (202X...@tjhsst.edu).
 
+    There are no more interest sessions scheduled for this year (2021). If you still are interested, please join [this Slack channel](https://tjcsl.slack.com) using your TJHSST student email (202X...@tjhsst.edu).
 
     ### Shadow Sessions
 


### PR DESCRIPTION
Some of the changes supposed to be in this commit ended up in a different one over on tjcsl/sysadmins-website, so make sure to check understudy.yml there as well. The commit that ended up with some of these changes is labeled "GitHub Actions CI, update content". I think this might have occurred due to a force push I did at just the right time, although I'm not entirely sure.